### PR TITLE
Fix pp calculate error when circle count is 0

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             int circle300Count = count300 - (objectCount - circleCount);
             if (circle300Count <= 0)
-                return 0;
+                return double.NaN;
 
             // Probability of landing a 300 where the player has a 20% chance of getting at least the given amount of 300s.
             double probability = Beta.InvCDF(circle300Count, 1 + circleCount - circle300Count, 0.2);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             int circle300Count = count300 - (objectCount - circleCount);
             if (circle300Count <= 0)
-                return double.NaN;
+                return 140 - 8 * od;    // Hit window for a 50. Worst case scenario for a score with no guarenteed circle 300s.
 
             // Probability of landing a 300 where the player has a 20% chance of getting at least the given amount of 300s.
             double probability = Beta.InvCDF(circle300Count, 1 + circleCount - circle300Count, 0.2);
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         private static double calculateAimWeight(double missWeight, double normalizedHitError, int combo, int maxCombo, int objectCount, Mod[] visualMods)
         {
-            double accuracyWeight = double.IsNaN(normalizedHitError) ? 0 : Math.Pow(0.995, normalizedHitError) * 1.04;
+            double accuracyWeight = Math.Pow(0.995, normalizedHitError) * 1.04;
             double comboWeight = Math.Pow(combo, 0.8) / Math.Pow(maxCombo, 0.8);
             double flashlightLengthWeight = visualMods.Any(m => m is OsuModFlashlight) ? 1 + Math.Atan(objectCount / 2000.0) : 1;
 
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         private static double calculateSpeedWeight(double missWeight, double normalizedHitError, int combo, int maxCombo)
         {
-            double accuracyWeight = double.IsNaN(normalizedHitError) ? 0 : Math.Pow(0.985, normalizedHitError) * 1.12;
+            double accuracyWeight = Math.Pow(0.985, normalizedHitError) * 1.12;
             double comboWeight = Math.Pow(combo, 0.4) / Math.Pow(maxCombo, 0.4);
 
             return accuracyWeight * comboWeight * missWeight;
@@ -119,6 +119,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             return lengthWeight * modWeight;
         }
 
-        private static double calculateAccuracyValue(double normalizedHitError) => double.IsNaN(normalizedHitError) ? 0 : 560 * Math.Pow(0.85, normalizedHitError);
+        private static double calculateAccuracyValue(double normalizedHitError) => 560 * Math.Pow(0.85, normalizedHitError);
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             int circle300Count = count300 - (objectCount - circleCount);
             if (circle300Count <= 0)
-                return 140 - 8 * od;    // Hit window for a 50. Worst case scenario for a score with no guarenteed circle 300s.
+                return 200 - od * 10;    // Hit window for a 50. Worst case scenario for a score with no guarenteed circle 300s.
 
             // Probability of landing a 300 where the player has a 20% chance of getting at least the given amount of 300s.
             double probability = Beta.InvCDF(circle300Count, 1 + circleCount - circle300Count, 0.2);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             int circle300Count = count300 - (objectCount - circleCount);
             if (circle300Count <= 0)
-                return double.NaN;
+                return 0;
 
             // Probability of landing a 300 where the player has a 20% chance of getting at least the given amount of 300s.
             double probability = Beta.InvCDF(circle300Count, 1 + circleCount - circle300Count, 0.2);

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/RhythmComplexity.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/RhythmComplexity.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {
     public class RhythmComplexity : Skill
     {
-        private int amountHitObjectsWithAccuracy;
+        private int circleCount;
         private int noteIndex;
         private bool isPreviousOffbeat;
         private readonly List<int> previousDoubles = new List<int>();
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             {
                 var osuCurrent = (OsuDifficultyHitObject)current;
                 difficultyTotal += calculateRhythmBonus(osuCurrent);
-                amountHitObjectsWithAccuracy++;
+                circleCount++;
             }
             else
                 isPreviousOffbeat = false;
@@ -40,11 +40,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public override double DifficultyValue()
         {
-            if (amountHitObjectsWithAccuracy == 0)
+            if (circleCount == 0)
                 return 0;
 
-            double lengthRequirement = Math.Tanh(amountHitObjectsWithAccuracy / 50.0);
-            return 1 + difficultyTotal / amountHitObjectsWithAccuracy * lengthRequirement;
+            double lengthRequirement = Math.Tanh(circleCount / 50.0);
+            return 1 + difficultyTotal / circleCount * lengthRequirement;
         }
 
         private double calculateRhythmBonus(OsuDifficultyHitObject current)

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/RhythmComplexity.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/RhythmComplexity.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {
     public class RhythmComplexity : Skill
     {
-        private int circleCount;
+        private int amountHitObjectsWithAccuracy;
         private int noteIndex;
         private bool isPreviousOffbeat;
         private readonly List<int> previousDoubles = new List<int>();
@@ -26,12 +26,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public override void Process(DifficultyHitObject current)
         {
-            var osuCurrent = (OsuDifficultyHitObject)current;
-
             if (current.BaseObject is HitCircle)
             {
+                var osuCurrent = (OsuDifficultyHitObject)current;
                 difficultyTotal += calculateRhythmBonus(osuCurrent);
-                circleCount++;
+                amountHitObjectsWithAccuracy++;
             }
             else
                 isPreviousOffbeat = false;
@@ -41,8 +40,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public override double DifficultyValue()
         {
-            double lengthRequirement = Math.Tanh(circleCount / 50.0);
-            return 1 + difficultyTotal / circleCount * lengthRequirement;
+            if (amountHitObjectsWithAccuracy == 0)
+                return 0;
+
+            double lengthRequirement = Math.Tanh(amountHitObjectsWithAccuracy / 50.0);
+            return 1 + difficultyTotal / amountHitObjectsWithAccuracy * lengthRequirement;
         }
 
         private double calculateRhythmBonus(OsuDifficultyHitObject current)


### PR DESCRIPTION
this is one of the beatmap link that will cause this problem:
https://osu.ppy.sh/beatmapsets/1713744#osu/3549141

this pr will let `RhythmComplexity` skill return 0 when circle count is 0

It is worth noting that I don't know why `normalisedHitError` will be NaN if count 300 is less then circle count, it will cause all skill to 0, so I adjust it to 0 but not NaN